### PR TITLE
chore: replace deprecated String.prototype.substr()

### DIFF
--- a/patches/hubot-discord+2.1.0.patch
+++ b/patches/hubot-discord+2.1.0.patch
@@ -11,7 +11,7 @@ index adbc45a..794dc87 100644
 +
 +        matches = text.match(new RegExp("^<@!#{@client.user.id}>"))
 +        if matches
-+          text = "#{@robot.name} #{text.substr(matches[0].length)}"
++          text = "#{@robot.name} #{text.slice(matches[0].length)}"
  
          if (message?.channel instanceof Discord.DMChannel)
            text = "#{@robot.name}: #{text}" if not text.match new RegExp( "^@?#{@robot.name}" )


### PR DESCRIPTION
## Description

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

## Performance impact

From past experience there is no performance impact due to switching to slice()

## Security impact

None as the returned values are still the same

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

